### PR TITLE
9 fix linker

### DIFF
--- a/deen-linker/src/linker.rs
+++ b/deen-linker/src/linker.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 pub struct ObjectLinker;
 
 impl ObjectLinker {
-    fn detect_compiler() -> Option<String> {
+    pub fn detect_compiler() -> Option<String> {
         let candidates = match std::env::consts::OS {
             "windows" => ["link", "gcc", "clang"],
             "macos" => ["clang", "gcc", "cc"],
@@ -36,14 +36,39 @@ impl ObjectLinker {
         let input = format!("{module_name}.o");
 
         if let Some(compiler) = Self::detect_compiler() {
-            let linker_output = std::process::Command::new(&compiler)
-                .arg(input.clone())
-                .args(includes_formatted)
-                .arg("-fPIC")
-                .arg("-lm")
-                .arg("-o")
-                .arg(output_path)
-                .output();
+            let linker_output = match compiler.as_str() {
+                "link" => {
+                    let msvc_path = r"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\lib\x64";
+                    let sdk_um_path = r"C:\Program Files (x86)\Windows Kits\10\lib\10.0.22000.0\um\x64";
+                    let sdk_ucrt_path = r"C:\Program Files (x86)\Windows Kits\10\lib\10.0.22000.0\ucrt\x64";
+
+                    std::process::Command::new(&compiler)
+                        .args(&[
+                            &input,
+                            &format!("/OUT:{}", output_path),
+                            &format!("/LIBPATH:{}", msvc_path),
+                            &format!("/LIBPATH:{}", sdk_um_path),
+                            &format!("/LIBPATH:{}", sdk_ucrt_path),
+                            "/SUBSYSTEM:CONSOLE",
+                            "/MACHINE:X64",
+                            "/ENTRY:mainCRTStartup",
+                            "/NODEFAULTLIB:msvcrt.lib",
+                            "libcmt.lib",
+                            "kernel32.lib",
+                            "user32.lib",
+                        ]).output()
+                },
+                _ => {
+                    std::process::Command::new(&compiler)
+                        .arg(input.clone())
+                        .args(includes_formatted)
+                        .arg("-fPIC")
+                        .arg("-lm")
+                        .arg("-o")
+                        .arg(output_path)
+                        .output()
+                }
+            };
 
             std::fs::remove_file(input).expect("Unable to delete object file");
 
@@ -52,7 +77,8 @@ impl ObjectLinker {
                 return Ok(compiler);
             }
 
-            return Err(String::from_utf8_lossy(&output.stderr).to_string());
+            let error_message = if output.stderr.is_empty() { String::from_utf8_lossy(&output.stdout).to_string() } else { String::from_utf8_lossy(&output.stderr).to_string() };
+            return Err(error_message);
         }
 
         Err(String::from(

--- a/deen/src/main.rs
+++ b/deen/src/main.rs
@@ -319,7 +319,8 @@ fn main() {
             args.include,
         )
         .unwrap_or_else(|err| {
-            cli::error("Linker catched an error!");
+            let object_linker = deen_linker::linker::ObjectLinker::detect_compiler().unwrap_or(String::from("none"));
+            cli::error(&format!("Linker catched an error! (object linker: `{}`)", object_linker));
             println!("\n{err}\n");
 
             cli::error(


### PR DESCRIPTION
### 🍀 Description
**Version:** `v1.1.0`
**Related:** #9 

<!--
Here you can describe changes and provide examples
-->
Implemented linkage with windows `link.exe` linker.
Now compiler supports 3 compilers (C compilers) for Windows: `gcc`/`clang`/`link`