### PR TITLE
Added structures declaration format checkers in parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "deen"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "clap",
  "colored",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "deen-codegen"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "deen-parser",
  "deen-semantic",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "deen-lexer"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "miette",
  "thiserror 2.0.12",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "deen-linker"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "inkwell",
  "llvm-sys",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "deen-parser"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "deen-lexer",
  "indexmap",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "deen-semantic"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "deen-lexer",
  "deen-parser",


### PR DESCRIPTION
### 🍀 Description
**Version:** `v1.1.0`
**Related:** #8

Added special checkers for structures declaration format verification in `deen-parser` (syntax analyzer) module.
Currently we have next structures declaration format:
```deen
struct Identifier {
  field: type, // every field name must be unique, separation with commas

  fn method() {} // methods only after fields. Fields after methods are not allowed
}
```

That changes also brought 3 new error-messages:
```
Fields after methods declaration found
```
```
Field `field` defined multiple times
```
```
Use commas instead of semicolons in structure declaration
```
