### PR TITLE
Allowed uninitialized structures fields with special prefix

### DIFF
--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -2276,14 +2276,14 @@ impl Analyzer {
                                             }
                                         });
 
-                                        let unassigned = assigned_fields.iter().filter(|x| !x.1).map(|x| x.0.to_owned().to_owned()).collect::<Vec<String>>();
-                                        if !unassigned.is_empty() {
-                                            let fmt = format!("`{}`", unassigned.join("` , `"));
-                                            self.error(
-                                                format!("Missing structure fields: {fmt}"),
-                                                *span
-                                            );
-                                        }
+                                        // let unassigned = assigned_fields.iter().filter(|x| !x.1).map(|x| x.0.to_owned().to_owned()).collect::<Vec<String>>();
+                                        // if !unassigned.is_empty() {
+                                        //     let fmt = format!("`{}`", unassigned.join("` , `"));
+                                        //     self.error(
+                                        //         format!("Missing structure fields: {fmt}"),
+                                        //         *span
+                                        //     );
+                                        // }
 
                                         prev_type_display = Type::Alias(name.clone());
                                         prev_type = import.structs.get(&name).unwrap().clone();
@@ -2623,7 +2623,7 @@ impl Analyzer {
 
                     let unassigned = assigned_fields
                         .iter()
-                        .filter(|x| !x.1)
+                        .filter(|x| !x.1 && !x.0.starts_with("__"))
                         .map(|x| x.0.to_owned().to_owned())
                         .collect::<Vec<String>>();
                     if !unassigned.is_empty() {


### PR DESCRIPTION
### 🍀 Description
**Version:** `1.1.0`
**Related:** #5

<!--
Here you can describe changes and provide examples
-->
This PR allows user to leave uninitialized structures fields with special prefix: `__`:
```deen
struct Foo {
  field: i32,
  __optional_field: i32,
}

fn main() {
  let structure = Foo { .field = 0 };
  let structure2 = Foo { .field = 0, .optional_field = 1 };
}
```