### PR TITLE
Add `_link_c` statement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,29 @@ dependencies = [
  "deen-parser",
  "indexmap",
  "miette",
+ "shellexpand",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
 ]
 
 [[package]]
@@ -259,6 +281,17 @@ checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -337,6 +370,16 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -419,6 +462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "owo-colors"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +489,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -472,6 +532,15 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "shlex"
@@ -606,6 +675,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "windows-sys"

--- a/deen-codegen/src/lib.rs
+++ b/deen-codegen/src/lib.rs
@@ -1387,6 +1387,8 @@ impl<'ctx> CodeGen<'ctx> {
                 }
             }
 
+            Statements::LinkCStatement { path: _, span: _ } => {},
+
             Statements::ExternDeclareStatement {
                 identifier,
                 datatype,

--- a/deen-codegen/src/lib.rs
+++ b/deen-codegen/src/lib.rs
@@ -582,7 +582,7 @@ impl<'ctx> CodeGen<'ctx> {
                     let prev_pos = self.builder.get_insert_block().unwrap();
 
                     self.builder.position_at_end(latest_block);
-                    
+
                     if let Some(instruction) = latest_block.get_last_instruction() {
                         if !instruction.is_terminator() {
                             self.builder.build_return(None).unwrap();
@@ -1387,7 +1387,7 @@ impl<'ctx> CodeGen<'ctx> {
                 }
             }
 
-            Statements::LinkCStatement { path: _, span: _ } => {},
+            Statements::LinkCStatement { path: _, span: _ } => {}
 
             Statements::ExternDeclareStatement {
                 identifier,

--- a/deen-lexer/src/lib.rs
+++ b/deen-lexer/src/lib.rs
@@ -121,6 +121,7 @@ impl Lexer {
                 std_keyword!("enum"),
                 std_keyword!("typedef"),
                 std_keyword!("_extern_declare"),
+                std_keyword!("_link_c"),
                 // Types
                 std_type!("i8"),
                 std_type!("i16"),

--- a/deen-parser/src/lib.rs
+++ b/deen-parser/src/lib.rs
@@ -569,6 +569,7 @@ impl Parser {
                 "include" => self.include_statement(),
                 "extern" => self.extern_statement(),
                 "_extern_declare" => self.extern_declare_statement(),
+                "_link_c" => self.link_c_statement(),
                 "if" => self.if_statement(),
                 "else" => {
                     self.error(

--- a/deen-parser/src/statements.rs
+++ b/deen-parser/src/statements.rs
@@ -1103,18 +1103,24 @@ impl Parser {
         if self.expect(TokenType::Keyword) {
             let _ = self.next();
         }
-        
+
         let path = self.expression();
         let span_end = Self::get_span_expression(path.clone()).1;
 
         if let Expressions::Value(Value::String(_), _) = path {
-            Statements::LinkCStatement { path, span: (span_start, span_end) }
+            Statements::LinkCStatement {
+                path,
+                span: (span_start, span_end),
+            }
         } else {
             self.error(
                 String::from("Expected string path for LinkC statement"),
-                (span_start, span_end)
+                (span_start, span_end),
             );
-            Statements::LinkCStatement { path, span: (span_start, span_end) }
+            Statements::LinkCStatement {
+                path,
+                span: (span_start, span_end),
+            }
         }
     }
 

--- a/deen-parser/src/statements.rs
+++ b/deen-parser/src/statements.rs
@@ -173,6 +173,12 @@ pub enum Statements {
         span: (usize, usize),
     },
 
+    /// `_link_c "PATH"`
+    LinkCStatement {
+        path: Expressions,
+        span: (usize, usize),
+    },
+
     /// `break`
     BreakStatements {
         span: (usize, usize),
@@ -287,10 +293,8 @@ impl Parser {
         }
 
         let path = self.expression();
-        self.position -= 1;
+        let span_end = Self::get_span_expression(path.clone()).1;
 
-        let span_end = self.current().span.1;
-        let _ = self.next();
         self.skip_eos();
 
         if let Expressions::Value(Value::String(_), _) = path {
@@ -1091,6 +1095,26 @@ impl Parser {
             identifier,
             datatype,
             span,
+        }
+    }
+
+    pub fn link_c_statement(&mut self) -> Statements {
+        let span_start = self.current().span.0;
+        if self.expect(TokenType::Keyword) {
+            let _ = self.next();
+        }
+        
+        let path = self.expression();
+        let span_end = Self::get_span_expression(path.clone()).1;
+
+        if let Expressions::Value(Value::String(_), _) = path {
+            Statements::LinkCStatement { path, span: (span_start, span_end) }
+        } else {
+            self.error(
+                String::from("Expected string path for LinkC statement"),
+                (span_start, span_end)
+            );
+            Statements::LinkCStatement { path, span: (span_start, span_end) }
         }
     }
 

--- a/deen-semantic/Cargo.toml
+++ b/deen-semantic/Cargo.toml
@@ -13,3 +13,4 @@ deen-lexer = { path = "../deen-lexer" }
 miette = { version = "7.5.0", features = ["fancy"] }
 thiserror = "2.0.12"
 indexmap = "2.9.0"
+shellexpand = "3.1.1"

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -243,8 +243,8 @@ impl Analyzer {
                     identifier: _,
                     datatype: _,
                     span: _,
-                } => {},
-                Statements::LinkCStatement { path: _, span: _ } => {},
+                } => {}
+                Statements::LinkCStatement { path: _, span: _ } => {}
                 _ => {
                     if let Some(err) = self.errors.last() {
                         if err.span == (255, 0).into() {
@@ -252,9 +252,7 @@ impl Analyzer {
                         };
                     }
                     self.error(
-                        String::from(
-                            "This item is not allowed in global scope!",
-                        ),
+                        String::from("This item is not allowed in global scope!"),
                         (0, 0),
                     );
                     return;
@@ -1004,7 +1002,8 @@ impl Analyzer {
 
                 if then_block_type != self.scope.expected
                     && then_block_type != Type::Void
-                    && then_block_type != Type::Undefined {
+                    && then_block_type != Type::Undefined
+                {
                     self.error(
                         format!(
                             "Expected type `{}` for scope, but found `{}`",
@@ -1389,15 +1388,15 @@ impl Analyzer {
                     return;
                 }
 
-                let included_path = Self::expand_library_path(import_path, true).unwrap_or_else(|err| {
-                    self.error(
-                        format!("Unable to resolve provided path: {}", err),
-                        *span
-                    );
-                    PathBuf::new()
-                });
+                let included_path =
+                    Self::expand_library_path(import_path, true).unwrap_or_else(|err| {
+                        self.error(format!("Unable to resolve provided path: {err}"), *span);
+                        PathBuf::new()
+                    });
 
-                if included_path.as_os_str().is_empty() { return };
+                if included_path.as_os_str().is_empty() {
+                    return;
+                };
 
                 // Reading source code
                 let src = std::fs::read_to_string(&included_path).unwrap_or_else(|err| {
@@ -1542,26 +1541,32 @@ impl Analyzer {
                         unreachable!()
                     };
 
-                let formatted_path = Self::expand_library_path(link_path, false).unwrap_or_else(|err| {
-                    self.error(
-                        format!("Unable to resolve linkage path: {}", err),
-                        *path_span
-                    );
-                    PathBuf::new()
-                });
+                let formatted_path =
+                    Self::expand_library_path(link_path, false).unwrap_or_else(|err| {
+                        self.error(format!("Unable to resolve linkage path: {err}"), *path_span);
+                        PathBuf::new()
+                    });
 
-                if formatted_path.as_os_str().is_empty() { return };
+                if formatted_path.as_os_str().is_empty() {
+                    return;
+                };
                 if !formatted_path.exists() {
                     self.error(
-                        format!("Provided linkage file does not exists: `{}`", formatted_path.as_os_str().to_str().unwrap()),
-                        *path_span
+                        format!(
+                            "Provided linkage file does not exists: `{}`",
+                            formatted_path.as_os_str().to_str().unwrap()
+                        ),
+                        *path_span,
                     );
                     return;
                 }
                 if !formatted_path.is_file() {
                     self.error(
-                        format!("Provided path is not file: `{}`", formatted_path.as_os_str().to_str().unwrap()),
-                        *path_span
+                        format!(
+                            "Provided path is not file: `{}`",
+                            formatted_path.as_os_str().to_str().unwrap()
+                        ),
+                        *path_span,
                     );
                     return;
                 }
@@ -3026,12 +3031,15 @@ impl Analyzer {
         }
     }
 
-    fn expand_library_path(path: impl AsRef<str>, is_deen_module: bool) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    fn expand_library_path(
+        path: impl AsRef<str>,
+        is_deen_module: bool,
+    ) -> Result<PathBuf, Box<dyn std::error::Error>> {
         let path = path.as_ref();
 
         if path.starts_with('@') {
             // standard library path
-            
+
             let deenlib_env = std::env::var(STANDARD_LIBRARY_VAR)?;
             let expanded_stdlib_path = shellexpand::full(&deenlib_env)?;
             let mut path_buffer = PathBuf::from(expanded_stdlib_path.as_ref());
@@ -3039,7 +3047,11 @@ impl Analyzer {
             let module_path = format!(
                 "{}{}",
                 path.replace("@", ""),
-                if !path.contains(".dn") && is_deen_module { ".dn" } else { "" }
+                if !path.contains(".dn") && is_deen_module {
+                    ".dn"
+                } else {
+                    ""
+                }
             );
 
             path_buffer.push(module_path);

--- a/deen-semantic/src/symtable.rs
+++ b/deen-semantic/src/symtable.rs
@@ -10,7 +10,7 @@ use std::{collections::HashMap, path::PathBuf};
 pub struct SymbolTable {
     pub imports: HashMap<String, Import>,
     pub included: HashMap<String, Include>,
-    pub linked: Vec<PathBuf>
+    pub linked: Vec<PathBuf>,
 }
 
 /// User Import Instance

--- a/deen-semantic/src/symtable.rs
+++ b/deen-semantic/src/symtable.rs
@@ -3,13 +3,14 @@
 //! Wikipedia Explanation: <https://en.wikipedia.org/wiki/Symbol_table>
 
 use deen_parser::{statements::Statements, types::Type};
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 /// Symbol Table Structure
 #[derive(Debug, Clone, Default)]
 pub struct SymbolTable {
     pub imports: HashMap<String, Import>,
     pub included: HashMap<String, Include>,
+    pub linked: Vec<PathBuf>
 }
 
 /// User Import Instance

--- a/deen/src/main.rs
+++ b/deen/src/main.rs
@@ -290,6 +290,9 @@ fn main() {
         .map(|n| n.to_string())
         .unwrap_or(fname.replace(".dn", ""));
 
+    // Combining linkages
+    let external_linkages = [args.include, symtable.linked.clone()].concat();
+
     // Code Generator Initialization.
     // Creating custom context and a very big wrapper for builder.
     let ctx = deen_codegen::CodeGen::create_context();
@@ -316,7 +319,7 @@ fn main() {
         let compiler = deen_linker::linker::ObjectLinker::link(
             &module_name,
             args.output.to_str().unwrap(),
-            args.include,
+            external_linkages,
         )
         .unwrap_or_else(|err| {
             let object_linker = deen_linker::linker::ObjectLinker::detect_compiler()


### PR DESCRIPTION
### 🍀 Description
**Version:** `v1.1.0`
**Related:** #16 

<!--
Here you can describe changes and provide examples
-->
As mentioned in related issue:
> ... compiler may need to automatically link C libraries with included Deen file ...

In this PR it was implemented by doing same things as in `include` tool. But linking external C file does NOT provides its functions! **You still have to declare them by `extern` keyword!**

Example:
`test.c`
```
#include <stdio.h>

void greet(char *name) {
  printf("Hello, %s!\n", name);
}
```
`main.dn`
```deen
_link_c "test.c"
extern "C" fn greet(*char);

fn main {
  greet("mealet");
}
```

_Output:_
> Hello, mealet!