### PR TITLE
Improved `stdlib.string` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,29 @@ dependencies = [
  "deen-parser",
  "indexmap",
  "miette",
+ "shellexpand",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
 ]
 
 [[package]]
@@ -259,6 +281,17 @@ checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -337,6 +370,16 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -419,6 +462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "owo-colors"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +489,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -472,6 +532,15 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "shlex"
@@ -606,6 +675,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "windows-sys"

--- a/deen-codegen/src/lib.rs
+++ b/deen-codegen/src/lib.rs
@@ -582,7 +582,7 @@ impl<'ctx> CodeGen<'ctx> {
                     let prev_pos = self.builder.get_insert_block().unwrap();
 
                     self.builder.position_at_end(latest_block);
-                    
+
                     if let Some(instruction) = latest_block.get_last_instruction() {
                         if !instruction.is_terminator() {
                             self.builder.build_return(None).unwrap();

--- a/deen-codegen/src/lib.rs
+++ b/deen-codegen/src/lib.rs
@@ -583,7 +583,11 @@ impl<'ctx> CodeGen<'ctx> {
 
                     self.builder.position_at_end(latest_block);
                     
-                    if !latest_block.get_last_instruction().unwrap().is_terminator() {
+                    if let Some(instruction) = latest_block.get_last_instruction() {
+                        if !instruction.is_terminator() {
+                            self.builder.build_return(None).unwrap();
+                        }
+                    } else {
                         self.builder.build_return(None).unwrap();
                     }
 

--- a/deen-codegen/src/lib.rs
+++ b/deen-codegen/src/lib.rs
@@ -1387,6 +1387,8 @@ impl<'ctx> CodeGen<'ctx> {
                 }
             }
 
+            Statements::LinkCStatement { path: _, span: _ } => {}
+
             Statements::ExternDeclareStatement {
                 identifier,
                 datatype,

--- a/deen-codegen/src/lib.rs
+++ b/deen-codegen/src/lib.rs
@@ -573,8 +573,21 @@ impl<'ctx> CodeGen<'ctx> {
                     .iter()
                     .for_each(|stmt| self.compile_statement(stmt.clone(), None));
 
-                if datatype == Type::Void || !function.verify(false) {
+                if datatype == Type::Void {
                     self.builder.build_return(None).unwrap();
+                }
+
+                if !function.verify(false) {
+                    let latest_block = function.get_last_basic_block().unwrap();
+                    let prev_pos = self.builder.get_insert_block().unwrap();
+
+                    self.builder.position_at_end(latest_block);
+                    
+                    if !latest_block.get_last_instruction().unwrap().is_terminator() {
+                        self.builder.build_return(None).unwrap();
+                    }
+
+                    self.builder.position_at_end(prev_pos);
                 }
 
                 self.exit_scope();

--- a/deen-codegen/src/lib.rs
+++ b/deen-codegen/src/lib.rs
@@ -573,7 +573,7 @@ impl<'ctx> CodeGen<'ctx> {
                     .iter()
                     .for_each(|stmt| self.compile_statement(stmt.clone(), None));
 
-                if datatype == Type::Void {
+                if datatype == Type::Void || !function.verify(false) {
                     self.builder.build_return(None).unwrap();
                 }
 
@@ -3131,7 +3131,7 @@ impl<'ctx> CodeGen<'ctx> {
         let args: Vec<BasicMetadataValueEnum> = [vec![message_ptr.into()], specifiers].concat();
         self.builder.build_call(panic_fn, &args, "").unwrap();
 
-        let _ = self.builder.build_return(None);
+        // let _ = self.builder.build_return(None);
     }
 
     fn create_panic_function(&mut self) -> FunctionValue<'ctx> {

--- a/deen-lexer/src/lib.rs
+++ b/deen-lexer/src/lib.rs
@@ -121,6 +121,7 @@ impl Lexer {
                 std_keyword!("enum"),
                 std_keyword!("typedef"),
                 std_keyword!("_extern_declare"),
+                std_keyword!("_link_c"),
                 // Types
                 std_type!("i8"),
                 std_type!("i16"),

--- a/deen-parser/src/lib.rs
+++ b/deen-parser/src/lib.rs
@@ -569,6 +569,7 @@ impl Parser {
                 "include" => self.include_statement(),
                 "extern" => self.extern_statement(),
                 "_extern_declare" => self.extern_declare_statement(),
+                "_link_c" => self.link_c_statement(),
                 "if" => self.if_statement(),
                 "else" => {
                     self.error(

--- a/deen-semantic/Cargo.toml
+++ b/deen-semantic/Cargo.toml
@@ -13,3 +13,4 @@ deen-lexer = { path = "../deen-lexer" }
 miette = { version = "7.5.0", features = ["fancy"] }
 thiserror = "2.0.12"
 indexmap = "2.9.0"
+shellexpand = "3.1.1"

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -1509,9 +1509,14 @@ impl Analyzer {
 
                 let include = Include { ast };
                 self.symtable.included.insert(module_name, include);
+
                 symtable.included.into_iter().for_each(|inc| {
-                    self.symtable.included.insert(inc.0, inc.1);
+                    let _ = self.symtable.included.insert(inc.0, inc.1);
                 });
+
+                symtable.linked.into_iter().for_each(|link| {
+                    let _ = self.symtable.linked.insert(link);
+                })
             }
 
             Statements::ExternDeclareStatement {

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -1571,7 +1571,7 @@ impl Analyzer {
                     return;
                 }
 
-                self.symtable.linked.push(formatted_path);
+                let _ = self.symtable.linked.insert(formatted_path);
             }
 
             Statements::ExternStatement {

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -1001,7 +1001,9 @@ impl Analyzer {
 
                 self.scope = *self.scope.parent.clone().unwrap();
 
-                if then_block_type != self.scope.expected && then_block_type != Type::Void {
+                if then_block_type != self.scope.expected
+                    && then_block_type != Type::Void
+                    && then_block_type != Type::Undefined {
                     self.error(
                         format!(
                             "Expected type `{}` for scope, but found `{}`",
@@ -1038,7 +1040,7 @@ impl Analyzer {
 
                     if then_block_type != else_block_type
                         && (then_block_type != Type::Undefined
-                            || else_block_type != Type::Undefined)
+                            && else_block_type != Type::Undefined)
                     {
                         self.error(
                             format!(

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -43,7 +43,7 @@ pub mod symtable;
 pub type SemanticOk = (SymbolTable, Vec<SemanticWarning>);
 pub type SemanticErr = (Vec<SemanticError>, Vec<SemanticWarning>);
 
-const STANDART_LIBRARY_VAR: &str = "DEEN_LIB";
+const STANDARD_LIBRARY_VAR: &str = "DEEN_LIB";
 
 /// Main Analyzer Struct
 #[derive(Debug)]
@@ -244,6 +244,7 @@ impl Analyzer {
                     datatype: _,
                     span: _,
                 } => {}
+                Statements::LinkCStatement { path: _, span: _ } => {}
                 _ => {
                     if let Some(err) = self.errors.last() {
                         if err.span == (255, 0).into() {
@@ -251,9 +252,7 @@ impl Analyzer {
                         };
                     }
                     self.error(
-                        String::from(
-                            "In global scope only allowed: functions definitions, imports",
-                        ),
+                        String::from("This item is not allowed in global scope!"),
                         (0, 0),
                     );
                     return;
@@ -1383,32 +1382,20 @@ impl Analyzer {
                     } else {
                         unreachable!()
                     };
-                let included_path = match import_path.chars().nth(0) {
-                    Some('@') => {
-                        // standart library path
 
-                        let lib_path = std::env::var(STANDART_LIBRARY_VAR).unwrap_or(
-                            std::env::current_dir()
-                                .unwrap()
-                                .to_str()
-                                .unwrap()
-                                .to_owned(),
-                        );
+                if import_path.is_empty() {
+                    self.error(String::from("Empty include path provided"), *path_span);
+                    return;
+                }
 
-                        let mut import_path = import_path.clone().replace(".dn", "");
-                        let _ = import_path.remove(0);
+                let included_path =
+                    Self::expand_library_path(import_path, true).unwrap_or_else(|err| {
+                        self.error(format!("Unable to resolve provided path: {err}"), *span);
+                        PathBuf::new()
+                    });
 
-                        let formatted_path = format!("{lib_path}/{import_path}.dn");
-                        PathBuf::from(formatted_path)
-                    }
-                    Some(_) => {
-                        // relative path
-                        PathBuf::from(import_path)
-                    }
-                    None => {
-                        self.error(String::from("Empty include path provided"), *path_span);
-                        return;
-                    }
+                if included_path.as_os_str().is_empty() {
+                    return;
                 };
 
                 // Reading source code
@@ -1544,6 +1531,47 @@ impl Analyzer {
 
                 // making variable `used`
                 let _ = self.scope.get_var(identifier);
+            }
+
+            Statements::LinkCStatement { path, span: _ } => {
+                let (link_path, path_span) =
+                    if let Expressions::Value(Value::String(path), span) = path {
+                        (path, span)
+                    } else {
+                        unreachable!()
+                    };
+
+                let formatted_path =
+                    Self::expand_library_path(link_path, false).unwrap_or_else(|err| {
+                        self.error(format!("Unable to resolve linkage path: {err}"), *path_span);
+                        PathBuf::new()
+                    });
+
+                if formatted_path.as_os_str().is_empty() {
+                    return;
+                };
+                if !formatted_path.exists() {
+                    self.error(
+                        format!(
+                            "Provided linkage file does not exists: `{}`",
+                            formatted_path.as_os_str().to_str().unwrap()
+                        ),
+                        *path_span,
+                    );
+                    return;
+                }
+                if !formatted_path.is_file() {
+                    self.error(
+                        format!(
+                            "Provided path is not file: `{}`",
+                            formatted_path.as_os_str().to_str().unwrap()
+                        ),
+                        *path_span,
+                    );
+                    return;
+                }
+
+                self.symtable.linked.push(formatted_path);
             }
 
             Statements::ExternStatement {
@@ -3000,6 +3028,37 @@ impl Analyzer {
             }
 
             _ => Ok(typ.clone()),
+        }
+    }
+
+    fn expand_library_path(
+        path: impl AsRef<str>,
+        is_deen_module: bool,
+    ) -> Result<PathBuf, Box<dyn std::error::Error>> {
+        let path = path.as_ref();
+
+        if path.starts_with('@') {
+            // standard library path
+
+            let deenlib_env = std::env::var(STANDARD_LIBRARY_VAR)?;
+            let expanded_stdlib_path = shellexpand::full(&deenlib_env)?;
+            let mut path_buffer = PathBuf::from(expanded_stdlib_path.as_ref());
+
+            let module_path = format!(
+                "{}{}",
+                path.replace("@", ""),
+                if !path.contains(".dn") && is_deen_module {
+                    ".dn"
+                } else {
+                    ""
+                }
+            );
+
+            path_buffer.push(module_path);
+            Ok(path_buffer)
+        } else {
+            // relative library path
+            Ok(PathBuf::from(path))
         }
     }
 }

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -1003,7 +1003,8 @@ impl Analyzer {
 
                 if then_block_type != self.scope.expected
                     && then_block_type != Type::Void
-                    && then_block_type != Type::Undefined {
+                    && then_block_type != Type::Undefined
+                {
                     self.error(
                         format!(
                             "Expected type `{}` for scope, but found `{}`",

--- a/deen-semantic/src/symtable.rs
+++ b/deen-semantic/src/symtable.rs
@@ -3,14 +3,17 @@
 //! Wikipedia Explanation: <https://en.wikipedia.org/wiki/Symbol_table>
 
 use deen_parser::{statements::Statements, types::Type};
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 /// Symbol Table Structure
 #[derive(Debug, Clone, Default)]
 pub struct SymbolTable {
     pub imports: HashMap<String, Import>,
     pub included: HashMap<String, Include>,
-    pub linked: Vec<PathBuf>,
+    pub linked: HashSet<PathBuf>,
 }
 
 /// User Import Instance

--- a/deen-semantic/src/symtable.rs
+++ b/deen-semantic/src/symtable.rs
@@ -3,13 +3,14 @@
 //! Wikipedia Explanation: <https://en.wikipedia.org/wiki/Symbol_table>
 
 use deen_parser::{statements::Statements, types::Type};
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 /// Symbol Table Structure
 #[derive(Debug, Clone, Default)]
 pub struct SymbolTable {
     pub imports: HashMap<String, Import>,
     pub included: HashMap<String, Include>,
+    pub linked: Vec<PathBuf>,
 }
 
 /// User Import Instance

--- a/deen/src/main.rs
+++ b/deen/src/main.rs
@@ -290,6 +290,9 @@ fn main() {
         .map(|n| n.to_string())
         .unwrap_or(fname.replace(".dn", ""));
 
+    // Combining linkages
+    let external_linkages = [args.include, symtable.linked.clone()].concat();
+
     // Code Generator Initialization.
     // Creating custom context and a very big wrapper for builder.
     let ctx = deen_codegen::CodeGen::create_context();
@@ -316,7 +319,7 @@ fn main() {
         let compiler = deen_linker::linker::ObjectLinker::link(
             &module_name,
             args.output.to_str().unwrap(),
-            args.include,
+            external_linkages,
         )
         .unwrap_or_else(|err| {
             let object_linker = deen_linker::linker::ObjectLinker::detect_compiler()

--- a/deen/src/main.rs
+++ b/deen/src/main.rs
@@ -291,7 +291,8 @@ fn main() {
         .unwrap_or(fname.replace(".dn", ""));
 
     // Combining linkages
-    let external_linkages = [args.include, symtable.linked.clone()].concat();
+    let linked_list: Vec<std::path::PathBuf> = symtable.linked.iter().cloned().collect();
+    let external_linkages = [args.include, linked_list].concat();
 
     // Code Generator Initialization.
     // Creating custom context and a very big wrapper for builder.

--- a/stdlib/bytes.dn
+++ b/stdlib/bytes.dn
@@ -1,5 +1,3 @@
-include "@string"
-
 extern "C" fn malloc(usize) *void;
 extern "C" fn realloc(*void, usize) *void;
 extern "C" fn free(*void);
@@ -28,7 +26,7 @@ pub struct Bytes {
       panic!("Null pointer apeared on heap allocation `Bytes.with_size`");
     }
 
-    return Bytes { .ptr = ptr, .size = sizeof!(u8) * size, .len = size, .iterator_ptr = 0 };
+    return Bytes { .ptr = ptr, .size = sizeof!(u8) * size, .len = 0, .iterator_ptr = 0 };
   }
 
   fn len(&self) usize {

--- a/stdlib/fs.dn
+++ b/stdlib/fs.dn
@@ -232,7 +232,7 @@ pub struct File {
       return FSError.WriteableModeException;
     }   
 
-    let raw_string = value.raw();
+    let raw_string = value.as_ptr();
 
     let pos = 0;
     let chr = raw_string[pos];

--- a/stdlib/string.c
+++ b/stdlib/string.c
@@ -1,0 +1,36 @@
+#include <stdlib.h>
+#include <string.h>
+
+// NOTE: This function is AI generated
+void __string_replace(char *src, char *from, char *to) {
+  if (!src || !from || !to)
+    return;
+
+  int src_len = strlen(src);
+  int from_len = strlen(from);
+  int to_len = strlen(to);
+
+  if (from_len == 0)
+    return;
+
+  char *temp = malloc(src_len * 2 + 1);
+  if (!temp)
+    return;
+
+  char *src_ptr = src;
+  char *temp_ptr = temp;
+
+  while (*src_ptr) {
+    if (strncmp(src_ptr, from, from_len) == 0) {
+      strcpy(temp_ptr, to);
+      temp_ptr += to_len;
+      src_ptr += from_len;
+    } else {
+      *temp_ptr++ = *src_ptr++;
+    }
+  }
+  *temp_ptr = '\0';
+
+  strcpy(src, temp);
+  free(temp);
+}

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -262,6 +262,13 @@ pub struct String {
     }
   }
 
+  fn clone_reversed(&self) String {
+    let instance = self.clone();
+    instance.reverse();
+
+    return instance;
+  }
+
   fn clear(&self) {
     let ptr = self.ptr;
     ptr[0] = '\0';

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -10,6 +10,9 @@ extern "C" fn strcpy(*char, *char);
 extern "C" fn strchr(*char, char) *char;
 extern "C" fn strstr(*char, *char) *char;
 
+extern "C" fn toupper(char) char;
+extern "C" fn tolower(char) char;
+
 pub struct String {
   ptr: *char,
   size: usize,
@@ -219,6 +222,15 @@ pub struct String {
       panic!("Unable to operate dropped string: `String.contains_str`");
     }
     return strstr(self.ptr, value) != NULL;
+  }
+
+  fn to_uppercase(&self) {
+    let ptr = self.ptr;
+
+    while *ptr != '\0' {
+      *ptr = toupper(*ptr);
+      ptr++;
+    }
   }
 
   fn as_ptr(&self) *char {

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -115,6 +115,10 @@ pub struct String {
     strcat(self.ptr, value);
   }
 
+  fn push_string(&self, value: String) {
+    self.push_str(value.ptr);
+  }
+
   fn pop(&self) char {
     if self.size < 1 {
       panic!("Unable to pop dropped string: `String.pop`");

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -59,6 +59,10 @@ pub struct String {
     return self.len;
   }
 
+  fn capacity(&self) usize {
+    return self.size;
+  }
+
   fn push(&self, value: char) {
     if self.size < 1 {
       panic!("Unable to push into dropped string: `String.push`");

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -182,7 +182,8 @@ pub struct String {
     }
     return strstr(self.ptr, value) != NULL;
   }
-  fn raw(&self) *char {
+
+  fn as_ptr(&self) *char {
     return self.ptr;
   }
 
@@ -236,6 +237,6 @@ pub struct String {
   }
 
   fn deref(&self) *char {
-    return self.raw();
+    return self.as_ptr();
   }
 }

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -1,3 +1,6 @@
+_link_c "@string.c"
+
+extern "C" fn __string_replace(*char, *char, *char);
 extern "C" fn memcpy(*void, *void, usize) *void;
 extern "C" fn malloc(usize) *void;
 extern "C" fn realloc(*void, usize) *void;
@@ -246,6 +249,10 @@ pub struct String {
       *ptr = tolower(*ptr);
       ptr++;
     }
+  }
+
+  fn replace(&self, from: *char, to: *char) {
+    __string_replace(self.ptr, from, to);
   }
 
   fn reverse(&self) {

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -13,6 +13,8 @@ extern "C" fn strstr(*char, *char) *char;
 extern "C" fn toupper(char) char;
 extern "C" fn tolower(char) char;
 
+include "@bytes"
+
 pub struct String {
   ptr: *char,
   size: usize,
@@ -278,6 +280,18 @@ pub struct String {
     ptr[0] = '\0';
 
     self.len = 0;
+  }
+
+  fn to_bytes(&self) Bytes {
+    let buffer = Bytes.with_size(self.len);
+    let ptr = self.ptr;
+
+    while *ptr != '\0' {
+      buffer.push(cast!(*ptr, u8));
+      ptr++;
+    }
+
+    return buffer;
   }
 
   fn as_ptr(&self) *char {

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -177,6 +177,36 @@ pub struct String {
     ptr[position] = value;
   }
 
+  fn find(&self, value: char) usize {
+    let ptr = strchr(self.ptr, value);
+    let offset: usize = 0;
+
+    while *ptr != '\0' {
+      ptr++;
+      offset++;
+    }
+
+    let len = self.len;
+    let position = len - offset;
+
+    return position;
+  }
+
+  fn find_str(&self, value: *char) usize {
+    let ptr = strstr(self.ptr, value);
+    let offset: usize = 0;
+
+    while *ptr != '\0' {
+      ptr++;
+      offset++;
+    }
+
+    let len = self.len;
+    let position = len - offset;
+
+    return position;
+  }
+
   fn contains(&self, value: char) bool {
     if self.size < 1 {
       panic!("Unable to operate dropped string: `String.contains`");

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -253,6 +253,17 @@ pub struct String {
 
   fn replace(&self, from: *char, to: *char) {
     __string_replace(self.ptr, from, to);
+
+    let new_size = strlen(self.ptr);
+    let new_ptr: *char = realloc(self.ptr, new_size);
+
+    if new_ptr == NULL {
+      panic!("Null pointer appeared on heap allocation: `String.replace`");
+    }
+
+    self.ptr = new_ptr;
+    self.size = new_size;
+    self.len = new_size;
   }
 
   fn reverse(&self) {

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -242,6 +242,13 @@ pub struct String {
     }
   }
 
+  fn clear(&self) {
+    let ptr = self.ptr;
+    ptr[0] = '\0';
+
+    self.len = 0;
+  }
+
   fn as_ptr(&self) *char {
     return self.ptr;
   }

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -242,6 +242,26 @@ pub struct String {
     }
   }
 
+  fn reverse(&self) {
+    if self.ptr == NULL || self.len < 1 {
+      return;
+    }
+
+    let ptr = self.ptr;
+    let len = strlen(ptr);
+    let start = 0;
+    let end = len - 1;
+    
+    while (start < end) {
+      let temp: char = ptr[start];
+      ptr[start] = ptr[end];
+      ptr[end] = temp;
+
+      start++;
+      end--;
+    }
+  }
+
   fn clear(&self) {
     let ptr = self.ptr;
     ptr[0] = '\0';

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -233,6 +233,15 @@ pub struct String {
     }
   }
 
+  fn to_lowercase(&self) {
+    let ptr = self.ptr;
+
+    while *ptr != '\0' {
+      *ptr = tolower(*ptr);
+      ptr++;
+    }
+  }
+
   fn as_ptr(&self) *char {
     return self.ptr;
   }

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -63,6 +63,10 @@ pub struct String {
     return self.size;
   }
 
+  fn is_empty(&self) bool {
+    return self.len == 0;
+  }
+
   fn push(&self, value: char) {
     if self.size < 1 {
       panic!("Unable to push into dropped string: `String.push`");


### PR DESCRIPTION
### 🍀 Description
**Version:** `<version>`
**Related:** #7 

<!--
Here you can describe changes and provide examples
-->

Implemented next functions from related issue:
**List of expected `String` methods:**
- `replace(&self, from: *char, to: *char)`
- `find(&self, pattern: char) usize`
- `find_str(&self, pattern: *char) usize`
- `to_uppercase(&self) String`
- `to_lowercase(&self) String`
- `to_bytes(&self) Bytes` (from `stdlib.bytes`)
- `raw(&self) *char` -> `as_ptr(&self) *char`
- `clear(&self)`
- `push_string(&self, other: String)`
- `is_empty(&self) bool`
- `capacity(&self) usize`
- `reverse(&self)`
- `clone_reversed(&self) String`
