### PR TITLE
Added new methods to `stdlib.string`

### DIFF
--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -37,7 +37,7 @@ pub struct String {
 
   fn from(value: *char) String {
     let len = strlen(value);
-    let size = sizeof!(char) * len;
+    let size = sizeof!(char) * len + 1;
     let ptr: *char = malloc(size);
 
     if ptr == NULL {
@@ -58,7 +58,7 @@ pub struct String {
   }
 
   fn with_capacity(capacity: usize) String {
-    let size = sizeof!(char) * capacity;
+    let size = sizeof!(char) * capacity + 1;
     let ptr: *char = malloc(size);
 
     if ptr == NULL {
@@ -91,7 +91,7 @@ pub struct String {
 
     self.len += 1;
 
-    if self.size < self.len {
+    if (self.size - 1) < self.len {
       let temp: *char = realloc(self.ptr, self.len);
 
       if temp == NULL {
@@ -105,6 +105,7 @@ pub struct String {
 
     let ptr = self.ptr;
     ptr[self.len - 1] = value;
+    ptr[self.len] = '\0';
   }
 
   fn push_str(&self, value: *char) {
@@ -114,7 +115,7 @@ pub struct String {
 
     self.len += strlen(value);
 
-    if self.size < self.len {
+    if (self.size - 1) < self.len {
       let temp: *char = realloc(self.ptr, self.len);
 
       if temp == NULL {
@@ -148,19 +149,6 @@ pub struct String {
     let output = ptr[self.len];
 
     ptr[self.len] = '\0';
-
-    if self.size > self.len {
-      let temp: *char = realloc(self.ptr, self.len);
-
-      if temp == NULL {
-        free(self.ptr);
-        panic!("Reallocation returned NULL pointer: `String.pop`");
-      }
-
-      self.ptr = temp;
-      self.size = self.len;
-    }
-
     return output;
   }
 

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -321,6 +321,15 @@ pub struct String {
     return buffer;
   }
 
+  fn truncate(&self, new_len: usize) {
+    if (new_len > self.len) { return; }
+
+    self.len = new_len;
+
+    let ptr = self.ptr;
+    ptr[self.len] = '\0';
+  }
+
   fn as_ptr(&self) *char {
     return self.ptr;
   }

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -48,6 +48,15 @@ pub struct String {
     return String { .ptr = ptr, .size = size, .len = len, .iterator_ptr = 0 };
   }
 
+  fn from_raw_parts(ptr: *void, len: usize, capacity: usize) String {
+    if ptr == NULL {
+      panic!("Null pointer appeared in raw creation: `String.from_raw_parts`");
+    }
+
+    let ptr: *char = ptr;
+    return String { .ptr = ptr, .size = capacity, .len = len, .iterator_ptr = 0 };
+  }
+
   fn with_capacity(capacity: usize) String {
     let size = sizeof!(char) * capacity;
     let ptr: *char = malloc(size);

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -152,6 +152,40 @@ pub struct String {
     return output;
   }
 
+  fn remove(&self, position: usize) {
+    if self.size < 1 {
+      panic!("Unable to use dropped string: `String.remove`");
+    }
+
+    if self.len < 1 { return; }
+
+    if position >= self.len {
+      panic!("Position is {}, but String len is {}: `String.remove`", position, self.len);
+    }
+
+    if position == (self.len - 1) {
+      let _ = self.pop();
+      return;
+    }
+
+    let ptr = self.ptr;
+    ptr += position;
+
+    let left = ptr;
+    let right = ptr;
+    
+    right += 1;
+
+    while *right != '\0' {
+      *left = *right;
+
+      left++;
+      right++;
+    }
+
+    *left = '\0';
+  }
+
   fn peek(&self, position: usize) char {
     if self.size < 1 {
       panic!("Unable to peek dropped string: `String.peek`");

--- a/stdlib/string.dn
+++ b/stdlib/string.dn
@@ -340,7 +340,9 @@ pub struct String {
       self.len = 0;
       self.size = 0;
 
-      free(self.ptr);
+      if (self.ptr != NULL) {
+        free(self.ptr);
+      }
     }
   }
 


### PR DESCRIPTION
### 🍀 Description
**Version:** `v1.1.0`
**Related:** #24 

<!--
Here you can describe changes and provide examples
-->
Implemented new functions for `stdlib.string` module:
- `fn remove(&self, position: usize)` - _removes character on specified position (capacity doesn't change)_
- `fn from_raw_parts(ptr: *void, len: usize, capacity: usize) String` - _creates new string instance with provided pointer, len and capacity_
- `fn truncate(&self, new_len: usize)` - _truncates string's len (capacity doesn't change)_

Also added some changes in compiler:
- Allowed annotations with `*void` pointers types
- Added `NULL` checker in `drop(&self)` method
- Added size reservation in String