### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build Deen Compiler
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/mealet/deen/security/code-scanning/1](https://github.com/mealet/deen/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or to the specific job(s) that limits the `GITHUB_TOKEN` permissions to the minimum required. In this case, the workflow checks out code and uploads build artifacts, so it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow (before `jobs:`), which will apply to all jobs unless overridden. This change should be made at the top of the `.github/workflows/build.yml` file, after the `name:` and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
