### PR TITLE
Added new types casts in `cast!()` macro

### DIFF
--- a/deen-codegen/src/macros.rs
+++ b/deen-codegen/src/macros.rs
@@ -395,6 +395,7 @@ impl<'ctx> StandartMacros<'ctx> for CodeGen<'ctx> {
                 match (&from_value.0, &to_type.0) {
                     (from, to) if from == to => from_value,
 
+                    // integer types cast
                     (from, to)
                         if deen_semantic::Analyzer::is_integer(from)
                             && deen_semantic::Analyzer::is_integer(to)
@@ -449,6 +450,7 @@ impl<'ctx> StandartMacros<'ctx> for CodeGen<'ctx> {
                         (to_type.0, value)
                     }
 
+                    // float types casts
                     (from, to)
                         if deen_semantic::Analyzer::is_float(from)
                             && deen_semantic::Analyzer::is_float(to) =>
@@ -481,6 +483,7 @@ impl<'ctx> StandartMacros<'ctx> for CodeGen<'ctx> {
                         (to_type.0, value)
                     }
 
+                    // `float -> integer` cast
                     (from, to)
                         if deen_semantic::Analyzer::is_float(from)
                             && deen_semantic::Analyzer::is_integer(to) =>
@@ -510,6 +513,7 @@ impl<'ctx> StandartMacros<'ctx> for CodeGen<'ctx> {
                         (to_type.0, value)
                     }
 
+                    // `integer -> float` cast
                     (from, to)
                         if deen_semantic::Analyzer::is_integer(from)
                             && deen_semantic::Analyzer::is_float(to) =>
@@ -539,8 +543,16 @@ impl<'ctx> StandartMacros<'ctx> for CodeGen<'ctx> {
                         (to_type.0, value)
                     }
 
+                    // `pointer -> integer` cast
                     (from, to) if matches!(from, &Type::Pointer(_)) && deen_semantic::Analyzer::is_integer(to) => {
                         let value = self.builder.build_ptr_to_int(from_value.1.into_pointer_value(), target_basic_type.into_int_type(), "").unwrap();
+
+                        (to_type.0, value.into())
+                    }
+
+                    // `integer -> pointer` cast
+                    (from, to) if deen_semantic::Analyzer::is_integer(from) && matches!(to, &Type::Pointer(_)) => {
+                        let value = self.builder.build_int_to_ptr(from_value.1.into_int_value(), target_basic_type.into_pointer_type(), "").unwrap();
 
                         (to_type.0, value.into())
                     }

--- a/deen-codegen/src/macros.rs
+++ b/deen-codegen/src/macros.rs
@@ -544,22 +544,51 @@ impl<'ctx> StandartMacros<'ctx> for CodeGen<'ctx> {
                     }
 
                     // `pointer -> integer` cast
-                    (from, to) if matches!(from, &Type::Pointer(_)) && deen_semantic::Analyzer::is_integer(to) => {
-                        let value = self.builder.build_ptr_to_int(from_value.1.into_pointer_value(), target_basic_type.into_int_type(), "").unwrap();
+                    (from, to)
+                        if matches!(from, &Type::Pointer(_))
+                            && deen_semantic::Analyzer::is_integer(to) =>
+                    {
+                        let value = self
+                            .builder
+                            .build_ptr_to_int(
+                                from_value.1.into_pointer_value(),
+                                target_basic_type.into_int_type(),
+                                "",
+                            )
+                            .unwrap();
 
                         (to_type.0, value.into())
                     }
 
                     // `integer -> pointer` cast
-                    (from, to) if deen_semantic::Analyzer::is_integer(from) && matches!(to, &Type::Pointer(_)) => {
-                        let value = self.builder.build_int_to_ptr(from_value.1.into_int_value(), target_basic_type.into_pointer_type(), "").unwrap();
+                    (from, to)
+                        if deen_semantic::Analyzer::is_integer(from)
+                            && matches!(to, &Type::Pointer(_)) =>
+                    {
+                        let value = self
+                            .builder
+                            .build_int_to_ptr(
+                                from_value.1.into_int_value(),
+                                target_basic_type.into_pointer_type(),
+                                "",
+                            )
+                            .unwrap();
 
                         (to_type.0, value.into())
                     }
 
                     // pointers types cast
-                    (from, to) if matches!(from, &Type::Pointer(_)) && matches!(to, &Type::Pointer(_)) => {
-                        let value = self.builder.build_pointer_cast(from_value.1.into_pointer_value(), target_basic_type.into_pointer_type(), "").unwrap();
+                    (from, to)
+                        if matches!(from, &Type::Pointer(_)) && matches!(to, &Type::Pointer(_)) =>
+                    {
+                        let value = self
+                            .builder
+                            .build_pointer_cast(
+                                from_value.1.into_pointer_value(),
+                                target_basic_type.into_pointer_type(),
+                                "",
+                            )
+                            .unwrap();
 
                         (to_type.0, value.into())
                     }

--- a/deen-codegen/src/macros.rs
+++ b/deen-codegen/src/macros.rs
@@ -539,6 +539,12 @@ impl<'ctx> StandartMacros<'ctx> for CodeGen<'ctx> {
                         (to_type.0, value)
                     }
 
+                    (from, to) if matches!(from, &Type::Pointer(_)) && deen_semantic::Analyzer::is_integer(to) => {
+                        let value = self.builder.build_ptr_to_int(from_value.1.into_pointer_value(), target_basic_type.into_int_type(), "").unwrap();
+
+                        (to_type.0, value.into())
+                    }
+
                     _ => panic!(
                         "Unimplemented cast type catched: `{}` -> `{}`",
                         from_value.0, to_type.0

--- a/deen-codegen/src/macros.rs
+++ b/deen-codegen/src/macros.rs
@@ -557,6 +557,13 @@ impl<'ctx> StandartMacros<'ctx> for CodeGen<'ctx> {
                         (to_type.0, value.into())
                     }
 
+                    // pointers types cast
+                    (from, to) if matches!(from, &Type::Pointer(_)) && matches!(to, &Type::Pointer(_)) => {
+                        let value = self.builder.build_pointer_cast(from_value.1.into_pointer_value(), target_basic_type.into_pointer_type(), "").unwrap();
+
+                        (to_type.0, value.into())
+                    }
+
                     _ => panic!(
                         "Unimplemented cast type catched: `{}` -> `{}`",
                         from_value.0, to_type.0

--- a/deen-parser/src/lib.rs
+++ b/deen-parser/src/lib.rs
@@ -448,9 +448,25 @@ impl Parser {
                 object: Box::new(self.term()),
                 span: (current.span.0, self.current().span.1),
             },
-            TokenType::Multiply => Expressions::Dereference {
-                object: Box::new(self.term()),
-                span: (current.span.0, self.current().span.1),
+            TokenType::Multiply => {
+                if self.expect(TokenType::Type) {
+                    self.position -= 1;
+
+                    let span_start = self.current().span.0;
+                    let parsed_type = self.parse_type();
+                    let span_end = self.current().span.1;
+
+                    return Expressions::Argument {
+                        name: String::from("@deen_type"),
+                        r#type: parsed_type,
+                        span: (span_start, span_end)
+                    };
+                }
+
+                Expressions::Dereference {
+                    object: Box::new(self.term()),
+                    span: (current.span.0, self.current().span.1),
+                }
             },
 
             // This case looks is for C-like syntax: `type name`,

--- a/deen-parser/src/lib.rs
+++ b/deen-parser/src/lib.rs
@@ -459,7 +459,7 @@ impl Parser {
                     return Expressions::Argument {
                         name: String::from("@deen_type"),
                         r#type: parsed_type,
-                        span: (span_start, span_end)
+                        span: (span_start, span_end),
                     };
                 }
 
@@ -467,7 +467,7 @@ impl Parser {
                     object: Box::new(self.term()),
                     span: (current.span.0, self.current().span.1),
                 }
-            },
+            }
 
             // This case looks is for C-like syntax: `type name`,
             // but syntax must be like: `name: type`

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -2052,7 +2052,6 @@ impl Analyzer {
                     //
                     //     Type::USIZE
                     // }
-
                     (Type::Alias(left), Type::Alias(right)) => {
                         let implementation_format: String =
                             format!("fn binary(&self, other: *{left}, operand: *char) {left}");
@@ -3448,19 +3447,13 @@ impl Analyzer {
             }
 
             // pointer to integer cast
-            _ if matches!(from, &Type::Pointer(_)) && Self::is_integer(to) => {
-                Ok(())
-            }
+            _ if matches!(from, &Type::Pointer(_)) && Self::is_integer(to) => Ok(()),
 
             // integer to pointer cast
-            _ if Self::is_integer(from) && matches!(to, &Type::Pointer(_)) => {
-                Ok(())
-            }
+            _ if Self::is_integer(from) && matches!(to, &Type::Pointer(_)) => Ok(()),
 
             // pointers types casts
-            _ if matches!(from, &Type::Pointer(_)) && matches!(to, &Type::Pointer(_)) => {
-                Ok(())
-            }
+            _ if matches!(from, &Type::Pointer(_)) && matches!(to, &Type::Pointer(_)) => Ok(()),
 
             _ if from == to => Ok(()),
             _ => Err(format!("Cast `{from}` -> `{to}` is unavaible")),

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -2023,35 +2023,35 @@ impl Analyzer {
                         }
                     }
 
-                    (Type::Pointer(_), r) if Self::is_integer(&r) => {
-                        if operand != "+" && operand != "-" {
-                            self.error(SemanticError::OperatorException {
-                                exception: "unsupported binary operator for pointer".to_string(),
-                                help: Some(
-                                    "Pointers arithemics supports only: `+` / `-`".to_string(),
-                                ),
-                                src: self.source.clone(),
-                                span: error::position_to_span(*span),
-                            });
-                        }
-
-                        left
-                    }
-
-                    (Type::Pointer(_), Type::Pointer(_)) => {
-                        if operand != "+" && operand != "-" {
-                            self.error(SemanticError::OperatorException {
-                                exception: "unsupported binary operator for pointer".to_string(),
-                                help: Some(
-                                    "Pointers arithemics supports only: `+` / `-`".to_string(),
-                                ),
-                                src: self.source.clone(),
-                                span: error::position_to_span(*span),
-                            });
-                        }
-
-                        Type::USIZE
-                    }
+                    // (Type::Pointer(_), r) if Self::is_integer(&r) => {
+                    //     if operand != "+" && operand != "-" {
+                    //         self.error(SemanticError::OperatorException {
+                    //             exception: "unsupported binary operator for pointer".to_string(),
+                    //             help: Some(
+                    //                 "Pointers arithemics supports only: `+` / `-`".to_string(),
+                    //             ),
+                    //             src: self.source.clone(),
+                    //             span: error::position_to_span(*span),
+                    //         });
+                    //     }
+                    //
+                    //     left
+                    // }
+                    //
+                    // (Type::Pointer(_), Type::Pointer(_)) => {
+                    //     if operand != "+" && operand != "-" {
+                    //         self.error(SemanticError::OperatorException {
+                    //             exception: "unsupported binary operator for pointer".to_string(),
+                    //             help: Some(
+                    //                 "Pointers arithemics supports only: `+` / `-`".to_string(),
+                    //             ),
+                    //             src: self.source.clone(),
+                    //             span: error::position_to_span(*span),
+                    //         });
+                    //     }
+                    //
+                    //     Type::USIZE
+                    // }
 
                     (Type::Alias(left), Type::Alias(right)) => {
                         let implementation_format: String =

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -3420,28 +3420,40 @@ impl Analyzer {
 
     fn verify_cast(&self, from: &Type, to: &Type) -> Result<(), String> {
         match (from, to) {
+            // integers types casts
             _ if Self::is_integer(from) && Self::is_integer(to) => Ok(()),
+
+            // float types casts
             _ if Self::is_float(from) && Self::is_float(to) => Ok(()),
 
+            // integers && float casts
             _ if (Self::is_integer(from) && Self::is_float(to))
                 || (Self::is_float(from) && Self::is_integer(to)) =>
             {
                 Ok(())
             }
 
+            // integer and `char` casts
             _ if (Self::is_integer(from) && to == &Type::Char)
                 || (from == &Type::Char && Self::is_integer(to)) =>
             {
                 Ok(())
             }
 
+            // boolean and integer casts
             _ if (from == &Type::Bool && Self::is_integer(to))
                 || (Self::is_integer(from) && to == &Type::Bool) =>
             {
                 Ok(())
             }
 
+            // pointer to integer cast
             _ if matches!(from, &Type::Pointer(_)) && Self::is_integer(to) => {
+                Ok(())
+            }
+
+            // integer to pointer cast
+            _ if Self::is_integer(from) && matches!(to, &Type::Pointer(_)) => {
                 Ok(())
             }
 

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -2023,21 +2023,20 @@ impl Analyzer {
                         }
                     }
 
-                    // (Type::Pointer(_), r) if Self::is_integer(&r) => {
-                    //     if operand != "+" && operand != "-" {
-                    //         self.error(SemanticError::OperatorException {
-                    //             exception: "unsupported binary operator for pointer".to_string(),
-                    //             help: Some(
-                    //                 "Pointers arithemics supports only: `+` / `-`".to_string(),
-                    //             ),
-                    //             src: self.source.clone(),
-                    //             span: error::position_to_span(*span),
-                    //         });
-                    //     }
-                    //
-                    //     left
-                    // }
-                    //
+                    (Type::Pointer(_), r) if Self::is_integer(&r) => {
+                        if operand != "+" && operand != "-" {
+                            self.error(SemanticError::OperatorException {
+                                exception: "unsupported binary operator for pointer".to_string(),
+                                help: Some(
+                                    "Pointers arithemics supports only: `+` / `-`".to_string(),
+                                ),
+                                src: self.source.clone(),
+                                span: error::position_to_span(*span),
+                            });
+                        }
+
+                        left
+                    }
 
                     // (Type::Pointer(_), Type::Pointer(_)) => {
                     //     if operand != "+" && operand != "-" {

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -2038,6 +2038,7 @@ impl Analyzer {
                     //     left
                     // }
                     //
+
                     // (Type::Pointer(_), Type::Pointer(_)) => {
                     //     if operand != "+" && operand != "-" {
                     //         self.error(SemanticError::OperatorException {
@@ -3438,6 +3439,10 @@ impl Analyzer {
             _ if (from == &Type::Bool && Self::is_integer(to))
                 || (Self::is_integer(from) && to == &Type::Bool) =>
             {
+                Ok(())
+            }
+
+            _ if matches!(from, &Type::Pointer(_)) && Self::is_integer(to) => {
                 Ok(())
             }
 

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -3457,6 +3457,11 @@ impl Analyzer {
                 Ok(())
             }
 
+            // pointers types casts
+            _ if matches!(from, &Type::Pointer(_)) && matches!(to, &Type::Pointer(_)) => {
+                Ok(())
+            }
+
             _ if from == to => Ok(()),
             _ => Err(format!("Cast `{from}` -> `{to}` is unavaible")),
         }


### PR DESCRIPTION
### 🍀 Description
**Version:** `v1.1.0`
**Related:** #22 

<!--
Here you can describe changes and provide examples
-->

Added new types casts in `cast!(EXPRESSION, TYPE)` macro:
- `pointer -> integer`
- `integer -> pointer`
- `pointer -> another pointer`

### Full Changelog
1. Added new casts types:
- `pointer -> integer`
- `integer -> pointer`
- `pointer -> another pointer`
2. Updated parser to handle pointers types: `*i32` (now will return Argument expression instead of dereference)