### PR TITLE
Added external functions and object compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "deen"
-version = "1.1.1"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "deen-codegen"
-version = "1.1.1"
+version = "1.1.3"
 dependencies = [
  "deen-parser",
  "deen-semantic",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "deen-lexer"
-version = "1.1.1"
+version = "1.1.3"
 dependencies = [
  "miette",
  "thiserror 2.0.12",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "deen-linker"
-version = "1.1.1"
+version = "1.1.3"
 dependencies = [
  "inkwell",
  "llvm-sys",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "deen-parser"
-version = "1.1.1"
+version = "1.1.3"
 dependencies = [
  "deen-lexer",
  "indexmap",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "deen-semantic"
-version = "1.1.1"
+version = "1.1.3"
 dependencies = [
  "deen-lexer",
  "deen-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.1"
+version = "1.1.3"
 edition = "2024"
 authors = ["mealet <workjason34@gmail.com>"]
 description = "Compiler of Deen Programming Language"

--- a/deen-codegen/src/lib.rs
+++ b/deen-codegen/src/lib.rs
@@ -522,7 +522,11 @@ impl<'ctx> CodeGen<'ctx> {
                     },
                     fn_type,
                     // if public { Some(Linkage::External) } else { None },
-                    if external { Some(Linkage::External) } else { None }
+                    if external {
+                        Some(Linkage::External)
+                    } else {
+                        None
+                    },
                 );
 
                 let entry = self.context.append_basic_block(function, "entry");

--- a/deen-codegen/src/lib.rs
+++ b/deen-codegen/src/lib.rs
@@ -481,27 +481,32 @@ impl<'ctx> CodeGen<'ctx> {
                 arguments,
                 block,
                 public: _,
+                external,
                 span: _,
                 header_span: _,
             } => {
                 let module_name = self.module.get_name().to_str().unwrap();
-                let name = format!("{}{}", prefix.clone().unwrap_or_default(), raw_name,);
+                let name = format!("{}{}", prefix.clone().unwrap_or_default(), raw_name);
 
-                let llvm_ir_name = format!(
-                    "{}{}{}({})",
-                    if module_name == "main" {
-                        "".to_owned()
-                    } else {
-                        format!("{module_name}.")
-                    },
-                    prefix.clone().unwrap_or_default(),
-                    raw_name,
-                    arguments
-                        .iter()
-                        .map(|arg| arg.1.to_string())
-                        .collect::<Vec<String>>()
-                        .join(", ")
-                );
+                let llvm_ir_name = if external {
+                    raw_name
+                } else {
+                    format!(
+                        "{}{}{}({})",
+                        if module_name == "main" {
+                            "".to_owned()
+                        } else {
+                            format!("{module_name}.")
+                        },
+                        prefix.clone().unwrap_or_default(),
+                        raw_name,
+                        arguments
+                            .iter()
+                            .map(|arg| arg.1.to_string())
+                            .collect::<Vec<String>>()
+                            .join(", ")
+                    )
+                };
 
                 let mut args: Vec<BasicMetadataTypeEnum<'ctx>> = Vec::new();
                 arguments.iter().for_each(|arg| {
@@ -516,8 +521,10 @@ impl<'ctx> CodeGen<'ctx> {
                         &llvm_ir_name
                     },
                     fn_type,
-                    None,
+                    // if public { Some(Linkage::External) } else { None },
+                    if external { Some(Linkage::External) } else { None }
                 );
+
                 let entry = self.context.append_basic_block(function, "entry");
 
                 let old_position = self.builder.get_insert_block();

--- a/deen-lexer/src/lib.rs
+++ b/deen-lexer/src/lib.rs
@@ -112,6 +112,7 @@ impl Lexer {
                 // Tech
                 std_keyword!("let"),
                 std_keyword!("pub"),
+                std_keyword!("ext"),
                 std_keyword!("fn"),
                 std_keyword!("import"),
                 std_keyword!("include"),

--- a/deen-parser/src/lib.rs
+++ b/deen-parser/src/lib.rs
@@ -625,9 +625,10 @@ impl Parser {
                 "struct" => self.struct_statement(),
                 "enum" => self.enum_statement(),
 
-                "pub" => {
+                "pub" | "ext" => {
                     let _ = self.next();
                     let stmt = self.statement();
+                    let ext_function = current.value == "ext";
 
                     match stmt {
                         Statements::FunctionDefineStatement {
@@ -636,6 +637,7 @@ impl Parser {
                             arguments,
                             block,
                             public: _,
+                            external,
                             span,
                             header_span,
                         } => Statements::FunctionDefineStatement {
@@ -644,6 +646,7 @@ impl Parser {
                             arguments,
                             block,
                             public: true,
+                            external: external || ext_function,
                             span,
                             header_span,
                         },

--- a/deen-parser/src/statements.rs
+++ b/deen-parser/src/statements.rs
@@ -70,6 +70,7 @@ pub enum Statements {
         arguments: Vec<(String, Type)>,
         block: Vec<Statements>,
         public: bool,
+        external: bool,
         span: (usize, usize),
         header_span: (usize, usize),
     },
@@ -728,6 +729,7 @@ impl Parser {
             arguments: arguments_tuples,
             block,
             public: false,
+            external: false,
             span: (span_start, span_end),
             header_span,
         }
@@ -969,6 +971,7 @@ impl Parser {
                         arguments: _,
                         public: _,
                         block: _,
+                        external: _,
                         span: _,
                         header_span: _,
                     } = &stmt
@@ -1134,6 +1137,7 @@ impl Parser {
                         datatype: _,
                         arguments: _,
                         public: _,
+                        external: _,
                         block: _,
                         span: _,
                         header_span: _,

--- a/deen-parser/tests/statements.rs
+++ b/deen-parser/tests/statements.rs
@@ -313,6 +313,7 @@ fn function_define_statement() {
             arguments,
             block,
             public,
+            external: _,
             span: _,
             header_span: _,
         }) => {
@@ -344,6 +345,7 @@ fn function_define_statement_with_type() {
             arguments,
             block,
             public,
+            external: _,
             span: _,
             header_span: _,
         }) => {
@@ -375,6 +377,7 @@ fn function_define_statement_with_args() {
             arguments,
             block,
             public,
+            external: _,
             span: _,
             header_span: _,
         }) => {
@@ -420,6 +423,7 @@ fn function_define_statement_with_block() {
             arguments,
             block,
             public,
+            external: _,
             span: _,
             header_span: _,
         }) => {
@@ -474,6 +478,7 @@ fn function_define_statement_public() {
             arguments,
             block,
             public,
+            external: _,
             span: _,
             header_span: _,
         }) => {
@@ -643,6 +648,7 @@ fn struct_define_with_fn_statement() {
                 arguments: _,
                 block: _,
                 public: _,
+                external: _,
                 span: _,
                 header_span: _,
             }) = functions.get("foo")
@@ -694,6 +700,7 @@ fn struct_define_public_statement() {
                 arguments: _,
                 block: _,
                 public: _,
+                external: _,
                 span: _,
                 header_span: _,
             }) = functions.get("foo")
@@ -792,6 +799,7 @@ fn enum_define_with_fn_statement() {
                 arguments: _,
                 block: _,
                 public: _,
+                external: _,
                 span: _,
                 header_span: _,
             }) = functions.get("foo")

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -204,6 +204,7 @@ impl Analyzer {
                     arguments: _,
                     block: _,
                     public: _,
+                    external: _,
                     span: _,
                     header_span: _,
                 } => {}
@@ -718,6 +719,7 @@ impl Analyzer {
                 arguments,
                 block,
                 public,
+                external,
                 span,
                 header_span,
             } => {
@@ -824,10 +826,10 @@ impl Analyzer {
 
                 self.scope = *self.scope.parent.clone().unwrap();
 
-                if *public && name == "main" {
+                if (*public || *external) && name == "main" {
                     self.error(SemanticError::VisibilityError {
-                        exception: "`main()` function is not allowed to be public".to_string(),
-                        help: Some("Consider removing `pub` keyword".to_string()),
+                        exception: "`main()` function is not allowed to be public/external".to_string(),
+                        help: Some("Consider removing visibility keyword".to_string()),
                         src: self.source.clone(),
                         span: error::position_to_span(*header_span),
                     });
@@ -979,6 +981,7 @@ impl Analyzer {
                         arguments,
                         block,
                         public,
+                        external,
                         span,
                         header_span,
                     } = wrapped_statement.clone()
@@ -999,6 +1002,7 @@ impl Analyzer {
                                 arguments,
                                 block,
                                 public,
+                                external,
                                 span,
                                 header_span,
                             };
@@ -1009,6 +1013,7 @@ impl Analyzer {
                                 arguments,
                                 block,
                                 public,
+                                external,
                                 span,
                                 header_span,
                             };

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -828,7 +828,8 @@ impl Analyzer {
 
                 if (*public || *external) && name == "main" {
                     self.error(SemanticError::VisibilityError {
-                        exception: "`main()` function is not allowed to be public/external".to_string(),
+                        exception: "`main()` function is not allowed to be public/external"
+                            .to_string(),
                         help: Some("Consider removing visibility keyword".to_string()),
                         src: self.source.clone(),
                         span: error::position_to_span(*header_span),

--- a/deen-semantic/src/lib.rs
+++ b/deen-semantic/src/lib.rs
@@ -157,7 +157,7 @@ impl Analyzer {
         if self.scope.get_fn("main").is_none() && self.scope.is_main {
             let err = SemanticError::GlobalError {
                 message: "Program has no entry `main` function".to_string(),
-                help: Some("Consider creating main function: `fn main()) {}`".to_string()),
+                help: Some("Consider creating main function: `fn main() {}`".to_string()),
                 src: self.source.clone(),
             };
 

--- a/deen/src/cli.rs
+++ b/deen/src/cli.rs
@@ -32,7 +32,6 @@ pub struct Args {
     /// `-l --link` flag to link C library to linker
     #[arg(short, long, action, help = "Link C library to linker")]
     pub link: Vec<PathBuf>,
-
 }
 
 /// Prints formatted red error message to _stderr_

--- a/deen/src/cli.rs
+++ b/deen/src/cli.rs
@@ -21,13 +21,18 @@ pub struct Args {
     #[arg(short, long, action, help = "Disable compiler's warnings")]
     pub no_warns: bool,
 
-    /// `-l --llvm` flag to enable compilation into LLVM IR
-    #[arg(short, long, action, help = "Enable compilation into LLVM IR")]
+    /// `--llvm` flag to enable compilation into LLVM IR
+    #[arg(long, action, help = "Enable compilation into LLVM IR")]
     pub llvm: bool,
 
-    /// `-i --include` flag to link C library to linker
-    #[arg(short, long, action, help = "Include C library to linker")]
-    pub include: Vec<PathBuf>,
+    /// `--object` flag to compile code without linkage and main function checker
+    #[arg(long, action, help = "Compile code to object file without linkage")]
+    pub object: bool,
+
+    /// `-l --link` flag to link C library to linker
+    #[arg(short, long, action, help = "Link C library to linker")]
+    pub link: Vec<PathBuf>,
+
 }
 
 /// Prints formatted red error message to _stderr_

--- a/deen/src/main.rs
+++ b/deen/src/main.rs
@@ -238,10 +238,7 @@ fn main() {
     // Imports aren't working currently | 20/06/2025 v0.0.4
     //
     // Analyzer takes only reference to AST (because we only provide checking)
-
-    // `is_main` flag is set to "NOT args.object" because if user enabled object compilation we
-    // should off main module checkers
-    let mut analyzer = deen_semantic::Analyzer::new(&src, fname, args.path.clone(), !args.object);
+    let mut analyzer = deen_semantic::Analyzer::new(&src, fname, args.path.clone(), !(args.object || args.llvm));
     let (symtable, warns) = match analyzer.analyze(&ast) {
         Ok(res) => res,
         Err((errors, warns)) => {

--- a/deen/src/main.rs
+++ b/deen/src/main.rs
@@ -238,7 +238,8 @@ fn main() {
     // Imports aren't working currently | 20/06/2025 v0.0.4
     //
     // Analyzer takes only reference to AST (because we only provide checking)
-    let mut analyzer = deen_semantic::Analyzer::new(&src, fname, args.path.clone(), !(args.object || args.llvm));
+    let mut analyzer =
+        deen_semantic::Analyzer::new(&src, fname, args.path.clone(), !(args.object || args.llvm));
     let (symtable, warns) = match analyzer.analyze(&ast) {
         Ok(res) => res,
         Err((errors, warns)) => {
@@ -324,7 +325,10 @@ fn main() {
         deen_linker::compiler::ObjectCompiler::compile_module(module_ref, &module_name);
 
         if args.object {
-            cli::info("Successfully", &format!("compiled to object file: {}.o", args.output.display()));
+            cli::info(
+                "Successfully",
+                &format!("compiled to object file: {}.o", args.output.display()),
+            );
             return;
         }
 


### PR DESCRIPTION
### 🍀 Description
**Version:** `v1.1.3`
**Related:** #31 

<!--
Here you can describe changes and provide examples
-->
1. Removed `-l` short flag for LLVM IR compilation (now only `--llvm`)
2. Flag `-i --include` replaced with `-l --link`
3. Added `--object` flag to compile source to object file (semantical main module checkers are disabled)
4. Flag `--llvm` now avoids main module checkers
5. Added **`ext`** visibility keyword to mark functions as external (this will add external linkage and avoid mangle)

Example:
```deen
ext fn add(a: i32, b: i32) i32 {
  return a + b;
}
```